### PR TITLE
Player initialization notification may differ from "apiready" on olde…

### DIFF
--- a/DailymotionPlayerSDK.podspec
+++ b/DailymotionPlayerSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'DailymotionPlayerSDK'
-  s.version          = '3.7.5'
+  s.version          = '3.7.6'
   s.summary          = 'Dailymotion iOS player (Swift)'
   s.homepage         = 'https://github.com/dailymotion/dailymotion-swift-player-sdk-ios'
   s.author           = 'Dailymotion'


### PR DESCRIPTION
### Player initialization notification may differ from "apiready" on older OSes

For now on iOS 11+, Dailymotion Player completed its loading state and we got notified through `func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!)` callback from `WKWebview`.

But on older devices and more specifically older versions of iOS, some SDK users might have faced an issue when they are trying to load a video just after creating the player.

**Solution: we consider now the player completely loaded when we receive an "apiready" event. It might fix a lot of "black player" issue which occured in the past on iOS 9**