### PR TITLE
New Apple tracking policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Add CHANGELOG.md
+
+### Changed
+- Use new AppTrackingTransparency framework to check the trackingAuthorizationStatus for iOS 14 and earlier 
+
+### Removed
+
+[3.8.0] 22/03/2021: https://github.com/dailymotion/dailymotion-swift-player-sdk-ios/releases/tag/3.8.0

--- a/DailymotionPlayerSDK/DMPlayerViewController.swift
+++ b/DailymotionPlayerSDK/DMPlayerViewController.swift
@@ -5,6 +5,7 @@
 import UIKit
 import WebKit
 import AdSupport
+import AppTrackingTransparency
 
 public protocol DMPlayerViewControllerDelegate: class {
   
@@ -414,9 +415,15 @@ extension DMPlayerViewController: WKUIDelegate {
 extension DMPlayerViewController {
   
   fileprivate func advertisingIdentifier() -> String? {
-    let canTrack = ASIdentifierManager.shared().isAdvertisingTrackingEnabled
-    let advertisingIdentifier = ASIdentifierManager.shared().advertisingIdentifier
+    let canTrack: Bool
+    if #available(iOS 14, *) {
+      canTrack =  ATTrackingManager.trackingAuthorizationStatus ==  ATTrackingManager.AuthorizationStatus.authorized
+    } else {
+      canTrack = ASIdentifierManager.shared().isAdvertisingTrackingEnabled
+    }
+
     if canTrack {
+      let advertisingIdentifier = ASIdentifierManager.shared().advertisingIdentifier
       #if swift(>=4.0)
       return advertisingIdentifier.uuidString
       #else

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - DailymotionPlayerSDK (3.7.11)
+  - DailymotionPlayerSDK (3.8.0)
 
 DEPENDENCIES:
   - DailymotionPlayerSDK (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  DailymotionPlayerSDK: 2c83881e0f266e436d5be69e36cb93cbbdc82e09
+  DailymotionPlayerSDK: 75f5d8d20f646fab64ecaf92a73ff62983f0efc3
 
 PODFILE CHECKSUM: c19d369ebab07d80302f722edcb86bcd803b45ea
 


### PR DESCRIPTION
### Added
- Add CHANGELOG.md

### Changed
- Use new AppTrackingTransparency framework to check the trackingAuthorizationStatus for iOS 14 and earlier 